### PR TITLE
Response examples - block

### DIFF
--- a/lib/api_browser/app/js/controllers/action.js
+++ b/lib/api_browser/app/js/controllers/action.js
@@ -12,6 +12,8 @@ app.controller('ActionCtrl', function($scope, $stateParams, Documentation) {
       return;
     }
 
+    $scope.example_response = $scope.action.example;
+
     // Extract the example and attach it to each attribute
     _.forEach(['headers', 'params', 'payload'], function(n) {
       var set = $scope.action[n];
@@ -43,13 +45,15 @@ app.controller('ActionCtrl', function($scope, $stateParams, Documentation) {
       }
     });
 
-    responsesWithTypes = _($scope.responses).map('media_type').compact().value();
+    if (!$scope.example_response) {
+      responsesWithTypes = _($scope.responses).map('media_type').compact().value();
 
-    // Only one response has a media type, so we can show it.
-    if (responsesWithTypes) {
-      Documentation.getType($stateParams.version, responsesWithTypes[0].id).then(function(response) {
-        $scope.example_response = response.data.example;
-      });
+      // Only one response has a media type, so we can show it.
+      if (responsesWithTypes) {
+        Documentation.getType($stateParams.version, responsesWithTypes[0].id).then(function(response) {
+          $scope.example_response = response.data.example;
+        });
+      }
     }
   }, function() {
     $scope.error = true;

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -50,6 +50,16 @@ module Praxis
       self.instance_eval(&block) if block_given?
     end
 
+    def example(&block)
+      if block_given?
+        @example = block
+      elsif @example && (ok_response = self.responses[:ok])
+        media_type = ok_response.media_type
+
+        media_type.load(@example.call(media_type.example.dump)).dump
+      end
+    end
+
     def update_attribute(attribute, options, block)
       attribute.options.merge!(options)
       attribute.type.attributes(options, &block)

--- a/lib/praxis/restful_doc_generator.rb
+++ b/lib/praxis/restful_doc_generator.rb
@@ -186,6 +186,7 @@ module Praxis
           next if action.metadata[:doc_visibility] == :none
 
           generated_examples = {}
+          response_example = action.example
           if action.params
             generated_examples[:params] = dump_example_for( r.id, action.params )
           end
@@ -195,6 +196,7 @@ module Praxis
           action_description = resource_description[:actions].find{|a| a[:name] == action_name }
           action_description[:params][:example] = generated_examples[:params] if generated_examples[:params]
           action_description[:payload][:example] = generated_examples[:payload] if generated_examples[:payload]
+          action_description[:example] = response_example if response_example
         end
 
         File.open(filename, 'w') {|f| f.write(JSON.pretty_generate(resource_description))}


### PR DESCRIPTION
The `example` method of an action takes a block. If there is an :ok response and that has a media type, this block will be called during doc generation with the rendered example. It must return a valid example for that media type, but can edit the given example as it sees fit.
